### PR TITLE
Release 1.06

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,108 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "laravelFileCreator.createClass",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createEnum",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createInterface",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createTrait",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createBladeFile",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createBladeComponentClass",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createConfig",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createCommand",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createSingleActionController",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createEvent",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createEventListener",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createException",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createFormRequest",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createJob",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createJsonResource",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createJsonResourceCollection",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createModel",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createMigration",
+          "when": "laravelFileCreator.activated"
+        },
+        {
+          "command": "laravelFileCreator.createMailable",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createNotification",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createPestTest",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createPolicy",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createResourceController",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createRule",
+          "when": "false"
+        },
+        {
+          "command": "laravelFileCreator.createLaravelFile",
+          "when": "false"
+        }
+      ],
       "explorer/context": [
         {
           "submenu": "laravelFileCreator.menu",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Laravel File Creator",
   "publisher": "junveloper",
   "description": "A Visual Studio Code Extension to create Laravel files from context menu in file explorer",
-  "version": "1.0.52",
+  "version": "1.0.6",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.8.0"

--- a/scripts/generatePackageJson.ts
+++ b/scripts/generatePackageJson.ts
@@ -20,6 +20,10 @@ type VSCodeContributes = {
     label: string;
   }>;
   menus: {
+    commandPalette: Array<{
+      command: string;
+      when: string;
+    }>;
     "explorer/context": Array<{
       submenu: string;
       group: string;
@@ -49,6 +53,14 @@ function generatePackageJsonConfig() {
     })),
     submenus: packageJson.contributes.submenus,
     menus: {
+      commandPalette: Object.values(commandsMapping).map(
+        (command: Command) => ({
+          command: command.commandName,
+          when: command.showInCommandPalette
+            ? "laravelFileCreator.activated"
+            : "false",
+        })
+      ),
       "explorer/context": packageJson.contributes.menus["explorer/context"],
       "laravelFileCreator.menu": Object.values(commandsMapping)
         .filter((command: Command) => command.configuration)
@@ -69,6 +81,11 @@ function generatePackageJsonConfig() {
     command: "laravelFileCreator.createLaravelFile",
     category: "Laravel File Creator",
     title: "Create Other Laravel Files...",
+  });
+
+  newContributes.menus.commandPalette.push({
+    command: "laravelFileCreator.createLaravelFile",
+    when: "false",
   });
 
   newContributes.menus["laravelFileCreator.menu"].push({

--- a/src/File/index.ts
+++ b/src/File/index.ts
@@ -1,5 +1,9 @@
 import { existsSync, writeFileSync } from "fs";
-import { window } from "vscode";
+import { Uri, window, workspace } from "vscode";
+import {
+  commandsMapping,
+  SupportedFileType,
+} from "../LaravelFile/commandMapping";
 
 function createFile(filePath: string, content: string) {
   if (existsSync(filePath)) {
@@ -26,4 +30,30 @@ function extractClassName(name: string) {
   return name.replace(/\.php+$/g, "");
 }
 
-export { createFile, extractClassName, removeExtension, sanitizeFileName };
+async function resolveDefaultUriForType(
+  type: SupportedFileType
+): Promise<Uri | undefined> {
+  const commandMapping = commandsMapping[type];
+
+  if (!commandMapping.defaultFilePath) {
+    return undefined;
+  }
+
+  const workspaceRoots = workspace.workspaceFolders;
+
+  if (!workspaceRoots || workspaceRoots.length === 0) {
+    return undefined;
+  }
+
+  const rootPath = workspaceRoots[0].uri.fsPath;
+
+  return Uri.file(`${rootPath}/${commandMapping.defaultFilePath}`);
+}
+
+export {
+  createFile,
+  extractClassName,
+  removeExtension,
+  resolveDefaultUriForType,
+  sanitizeFileName,
+};

--- a/src/File/index.ts
+++ b/src/File/index.ts
@@ -22,7 +22,11 @@ function removeExtension(name: string) {
   return name.split(".")[0];
 }
 
-function sanitizeFileName(name: string) {
+function sanitizeFileName(name: string, type: SupportedFileType) {
+  if (type === "Migration") {
+    return removeExtension(name.toLocaleLowerCase().replace(/\s+/g, "_"));
+  }
+
   return removeSpaces(removeExtension(name));
 }
 

--- a/src/LaravelFile/commandMapping.ts
+++ b/src/LaravelFile/commandMapping.ts
@@ -426,7 +426,7 @@ export const commandsMapping: Record<SupportedFileType, Command> = {
     commandName: "laravelFileCreator.createMigration",
     title: "New Migration",
     placeHolder: "Migration Name",
-    prompt: "Name of Migration (use snake case)",
+    prompt: "Use snake case or separate words with spaces",
     contextTitle: "Create Migration",
     group: `1_laravelFileCreator@${
       getEnumIndex(SupportedFileType, SupportedFileType.Migration) + 1

--- a/src/LaravelFile/commandMapping.ts
+++ b/src/LaravelFile/commandMapping.ts
@@ -8,6 +8,7 @@ export type Command = InputBoxOptions & {
   when: string;
   group: string;
   showInCommandPalette?: boolean;
+  defaultFilePath?: string;
   configuration: {
     key: string;
     type: string;
@@ -432,6 +433,7 @@ export const commandsMapping: Record<SupportedFileType, Command> = {
     }`,
     when: "explorerResourceIsFolder && laravelFileCreator.activated && config.laravelFileCreator.showCreateMigration",
     showInCommandPalette: true,
+    defaultFilePath: "database/migrations",
     configuration: {
       key: "laravelFileCreator.showCreateMigration",
       type: "boolean",

--- a/src/LaravelFile/commandMapping.ts
+++ b/src/LaravelFile/commandMapping.ts
@@ -7,6 +7,7 @@ export type Command = InputBoxOptions & {
   contextTitle: string;
   when: string;
   group: string;
+  showInCommandPalette?: boolean;
   configuration: {
     key: string;
     type: string;
@@ -430,6 +431,7 @@ export const commandsMapping: Record<SupportedFileType, Command> = {
       getEnumIndex(SupportedFileType, SupportedFileType.Migration) + 1
     }`,
     when: "explorerResourceIsFolder && laravelFileCreator.activated && config.laravelFileCreator.showCreateMigration",
+    showInCommandPalette: true,
     configuration: {
       key: "laravelFileCreator.showCreateMigration",
       type: "boolean",

--- a/src/LaravelFile/index.ts
+++ b/src/LaravelFile/index.ts
@@ -21,23 +21,23 @@ export default async function createLaravelFile(
     return;
   }
 
-  const destinationFolder =
+  const locationFolder =
     folder ||
     (await resolveDefaultUriForType(type)) ||
     (await promptFolderSelection());
 
-  if (!destinationFolder) {
+  if (!locationFolder) {
     return;
   }
 
-  baseName = sanitizeFileName(baseName);
+  baseName = sanitizeFileName(baseName, type);
 
   const className = extractClassName(baseName);
 
-  const namespace = await resolveNamespace(destinationFolder.fsPath);
+  const namespace = await resolveNamespace(locationFolder.fsPath);
 
   const fileName = convertBasenameToFileName(type, baseName);
-  const filePath = destinationFolder.fsPath + path.sep + fileName;
+  const filePath = locationFolder.fsPath + path.sep + fileName;
 
   const content = generateLaravelFile(type, className, namespace);
 

--- a/src/Namespace/index.ts
+++ b/src/Namespace/index.ts
@@ -68,8 +68,6 @@ export default async function resolveNamespace(
     .filter((entry) => entry !== null);
 
   if (pathMatches.length === 0) {
-    window.showErrorMessage("The namespace could not be resolved.");
-
     return undefined;
   }
 


### PR DESCRIPTION
- Only `Create Migration` will show up in Command Palette. Migration will always end up in `database/migrations` folder and selecting of folder is not required.

- When naming migration file, it now supports typing with spaces instead of using snake case. 